### PR TITLE
[WIP] Update README.md for using quickfix-window

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 #vim-qfstatusline
 
-This Vim plugin is plugin supporting [watchdogs](https://github.com/osyo-manga/vim-watchdogs).  
-If [watchdogs](https://github.com/osyo-manga/vim-watchdogs) check syntax error,  
+This Vim plugin is plugin supporting [watchdogs](https://github.com/osyo-manga/vim-watchdogs).
+If [watchdogs](https://github.com/osyo-manga/vim-watchdogs) check syntax error,
 this plugin execute statusline plugin function and statusline plugin call back to get error messages.
 
 ##Requirement
@@ -18,8 +18,8 @@ this plugin execute statusline plugin function and statusline plugin call back t
 ##Usage
 ###Installation
 
-Sample setting is using [NeoBundle](https://github.com/Shougo/neobundle.vim).  
-This setting is not working. However it's plugins setting hint.  
+Sample setting is using [NeoBundle](https://github.com/Shougo/neobundle.vim).
+This setting is not working. However it's plugins setting hint.
 Please check Requirement plugins's READE.md. thanx :)
 
 ```vim
@@ -41,7 +41,7 @@ function! StatuslineUpdate()
     return qfstatusline#Update()
 endfunction
 let g:Qfstatusline#UpdateCmd = function('StatuslineUpdate')
-set statusline=\ %{mode()}\ \|\ %t\ %m\ %r\ %h\ %w\ %q\ %{StatuslineUpdate()}%=\|\ %Y\ \|\ %{&fileformat}\ \|\ %{&fileencoding}\ 
+set statusline=\ %{mode()}\ \|\ %t\ %m\ %r\ %h\ %w\ %q\ %{StatuslineUpdate()}%=\|\ %Y\ \|\ %{&fileformat}\ \|\ %{&fileencoding}\
 ```
 
 ###lightline.vim setting
@@ -55,6 +55,17 @@ let g:lightline = {
 \    'component_expand': {'qfstatusline': 'qfstatusline#Update'},
 \    'component_type':   {'qfstatusline': 'error'}}
 let g:Qfstatusline#UpdateCmd = function('lightline#update')
+```
+
+#### using also quickfix window
+You need to add `'hook/back_window/enable_exit' : 1` , when using quickfix window with lightline.vim.
+
+```vim
+let g:quickrun_config = {
+\    'watchdogs_checker/_' : {
+\        'hook/back_window/enable_exit' : 1,
+\        'hook/qfstatusline_update/enable_exit':   1,
+\        'hook/qfstatusline_update/priority_exit': 4,},}
 ```
 
 ## Author


### PR DESCRIPTION
### 概要

lightline.vim を利用しつつ quickfix ウィンドウでの出力を行う際には、
`'hook/back_window/enable_exit' : 1,` が必要でしたのでREADME.mdに加筆しました。

元々の設定が `'outputter/quickfix/open_cmd': '',` 前提で記載されているようです。
しかし、 `BASE` 部分には記載されておらず、 `BASE` + `LIGHTLINE.VIM` の通りにするとデフォルトでquickfix ウィンドウも開いてしまうので、lightline.vim側のステータス表示も正常に行えないような気がします。

ちょっと表記を変えた方がいいのかもと思ったのですが、文章の体裁や再現性の確認を確認してからの方がいいかと思い、一旦ここでPRします。
#### 今回手元で確認した内容

http://d.hatena.ne.jp/osyo-manga/20130802/1375454074 によると  

> 一時的に quickfix ウィンドウへとカーソルが移動してしまい、シンタックスチェックを行ったウィンドウとは別のウィンドウへと移動してしまうことがあります。

とのことで、私の環境では
- 1度目の `:w` 時には quickfix ウィンドウが開くが、lightline.vim のステータス表示へは反映されない
- 2度目以降の `:w` 時にはlightline.vimへも反映される

という状況でした。

```
MacCustom Version 7.4 (KaoriYa 20151216),
本日NeoBundleUpdate! した vim-qfstatusline, lightline.vim, vim-watchdogs, vim-quickrun
```

そこで、  
http://d.hatena.ne.jp/syngan/20130125/1359120567 のコメントでのやりとりと、
https://github.com/osyo-manga/shabadou.vim/blob/master/doc/shabadou.jax#L401
を踏まえ、以下のように設定するとlightline.vim にステータス表示しつつ、 quickfix ウィンドウにも出力することができました。

``` vim
let g:quickrun_config = {
  \ 'watchdogs_checker/_': {
  \   'hook/back_window/enable_exit' : 1,
  \   'hook/qfstatusline_update/enable_exit': 1,
  \   'hook/qfstatusline_update/priority_exit': 1
  \ }
  \}
```
